### PR TITLE
Avoid a bug in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.4.0-beta1'
+        classpath 'com.android.tools.build:gradle:1.3.0'
         classpath "com.android.databinding:dataBinder:1.0-rc1"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Gradle fails with:

    Error:Execution failed for task ':app:mergeDebugResources'.
    > java.lang.Error: Could not find class: apple.awt.CGraphicsEnvironment

This is a bug in the beta version of gradle ([see bug report](https://code.google.com/p/android/issues/detail?id=162448)). Downgrading to 1.3.0 fixes it.