### PR TITLE
Exclude common views

### DIFF
--- a/app/src/main/java/com/lgvalle/material_animations/AnimationsActivity1.java
+++ b/app/src/main/java/com/lgvalle/material_animations/AnimationsActivity1.java
@@ -4,13 +4,13 @@ import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.transition.Fade;
+import android.transition.Transition;
 import android.transition.TransitionManager;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-
 import com.lgvalle.material_animations.databinding.ActivityAnimations1Binding;
 
 public class AnimationsActivity1 extends BaseDetailActivity {
@@ -31,7 +31,9 @@ public class AnimationsActivity1 extends BaseDetailActivity {
     }
 
     private void setupWindowAnimations() {
-        getWindow().setReenterTransition(new Fade());
+        Transition reEnterTransition = new Fade();
+        TransitionHelper.excludeTargets(reEnterTransition);
+        getWindow().setReenterTransition(reEnterTransition);
     }
 
     private void bindData() {

--- a/app/src/main/java/com/lgvalle/material_animations/AnimationsActivity2.java
+++ b/app/src/main/java/com/lgvalle/material_animations/AnimationsActivity2.java
@@ -43,7 +43,11 @@ public class AnimationsActivity2 extends BaseDetailActivity {
     }
 
     private void setupWindowAnimations() {
-        getWindow().setEnterTransition(TransitionInflater.from(this).inflateTransition(R.transition.slide_from_bottom));
+        Transition enterTransition = TransitionInflater.from(this).inflateTransition(
+            R.transition.slide_from_bottom);
+
+        TransitionHelper.excludeTargets(enterTransition);
+        getWindow().setEnterTransition(enterTransition);
         getWindow().getEnterTransition().addListener(new Transition.TransitionListener() {
             @Override
             public void onTransitionStart(Transition transition) {

--- a/app/src/main/java/com/lgvalle/material_animations/MainActivity.java
+++ b/app/src/main/java/com/lgvalle/material_animations/MainActivity.java
@@ -30,6 +30,7 @@ public class MainActivity extends AppCompatActivity {
         Slide slideTransition = new Slide();
         slideTransition.setSlideEdge(Gravity.LEFT);
         slideTransition.setDuration(getResources().getInteger(R.integer.anim_duration_long));
+        TransitionHelper.excludeTargets(slideTransition);
         getWindow().setReenterTransition(slideTransition);
         getWindow().setExitTransition(slideTransition);
     }

--- a/app/src/main/java/com/lgvalle/material_animations/RevealActivity.java
+++ b/app/src/main/java/com/lgvalle/material_animations/RevealActivity.java
@@ -58,6 +58,7 @@ public class RevealActivity extends BaseDetailActivity implements View.OnTouchLi
 
     private void setupEnterAnimations() {
         Transition transition = TransitionInflater.from(this).inflateTransition(R.transition.changebounds_with_arcmotion);
+        TransitionHelper.excludeTargets(transition);
         getWindow().setSharedElementEnterTransition(transition);
         transition.addListener(new Transition.TransitionListener() {
             @Override

--- a/app/src/main/java/com/lgvalle/material_animations/SharedElementActivity.java
+++ b/app/src/main/java/com/lgvalle/material_animations/SharedElementActivity.java
@@ -4,8 +4,8 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.transition.ChangeBounds;
 import android.transition.Slide;
+import android.transition.Transition;
 import android.view.Gravity;
-
 import com.lgvalle.material_animations.databinding.ActivitySharedelementBinding;
 
 public class SharedElementActivity extends BaseDetailActivity {
@@ -28,6 +28,8 @@ public class SharedElementActivity extends BaseDetailActivity {
 
     private void setupWindowAnimations() {
         // We are not interested in defining a new Enter Transition. Instead we change default transition duration
+        Transition enterTransition = getWindow().getEnterTransition();
+        TransitionHelper.excludeTargets(enterTransition);
         getWindow().getEnterTransition().setDuration(getResources().getInteger(R.integer.anim_duration_long));
     }
 

--- a/app/src/main/java/com/lgvalle/material_animations/TransitionActivity1.java
+++ b/app/src/main/java/com/lgvalle/material_animations/TransitionActivity1.java
@@ -30,6 +30,7 @@ public class TransitionActivity1 extends BaseDetailActivity {
 
     private void setupWindowAnimations() {
         Visibility enterTransition = buildEnterTransition();
+        TransitionHelper.excludeTargets(enterTransition);
         getWindow().setEnterTransition(enterTransition);
     }
 
@@ -101,12 +102,14 @@ public class TransitionActivity1 extends BaseDetailActivity {
         enterTransition.setDuration(getResources().getInteger(R.integer.anim_duration_long));
         // This view will not be affected by enter transition animation
         enterTransition.excludeTarget(R.id.square_red, true);
+        TransitionHelper.excludeTargets(enterTransition);
         return enterTransition;
     }
 
     private Visibility buildReturnTransition() {
         Visibility enterTransition = new Slide();
         enterTransition.setDuration(getResources().getInteger(R.integer.anim_duration_long));
+        TransitionHelper.excludeTargets(enterTransition);
         return enterTransition;
     }
 }

--- a/app/src/main/java/com/lgvalle/material_animations/TransitionActivity2.java
+++ b/app/src/main/java/com/lgvalle/material_animations/TransitionActivity2.java
@@ -37,8 +37,11 @@ public class TransitionActivity2 extends BaseDetailActivity {
         }  else {
             transition = TransitionInflater.from(this).inflateTransition(R.transition.explode);
         }
+
+        TransitionHelper.excludeTargets(transition);
         getWindow().setEnterTransition(transition);
     }
+
 
     private void setupLayout() {
         findViewById(R.id.exit_button).setOnClickListener(new View.OnClickListener() {
@@ -52,6 +55,7 @@ public class TransitionActivity2 extends BaseDetailActivity {
     private Transition buildEnterTransition() {
         Explode enterTransition = new Explode();
         enterTransition.setDuration(getResources().getInteger(R.integer.anim_duration_long));
+        TransitionHelper.excludeTargets(enterTransition);
         return enterTransition;
     }
 

--- a/app/src/main/java/com/lgvalle/material_animations/TransitionActivity3.java
+++ b/app/src/main/java/com/lgvalle/material_animations/TransitionActivity3.java
@@ -39,6 +39,8 @@ public class TransitionActivity3 extends BaseDetailActivity {
         }  else {
             transition = TransitionInflater.from(this).inflateTransition(R.transition.slide_from_bottom);
         }
+
+        TransitionHelper.excludeTargets(transition);
         getWindow().setEnterTransition(transition);
     }
 
@@ -55,6 +57,7 @@ public class TransitionActivity3 extends BaseDetailActivity {
         Slide enterTransition = new Slide();
         enterTransition.setDuration(getResources().getInteger(R.integer.anim_duration_long));
         enterTransition.setSlideEdge(Gravity.RIGHT);
+        TransitionHelper.excludeTargets(enterTransition);
         return enterTransition;
     }
 

--- a/app/src/main/java/com/lgvalle/material_animations/TransitionHelper.java
+++ b/app/src/main/java/com/lgvalle/material_animations/TransitionHelper.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.util.Pair;
+import android.transition.Transition;
 import android.view.View;
 
 import java.util.ArrayList;
@@ -70,4 +71,9 @@ public class TransitionHelper {
         participants.add(new Pair<>(view, view.getTransitionName()));
     }
 
+    public static void excludeTargets(Transition transition) {
+        transition.excludeTarget(android.R.id.statusBarBackground, true);
+        transition.excludeTarget(android.R.id.navigationBarBackground, true);
+        transition.excludeTarget(R.id.toolbar, true);
+    }
 }


### PR DESCRIPTION
Added a method on `TransitionHelper` to exclude common views in all Transitions such as the _statusBar_, _toolbar_ or _navigationBar_. Bringing more continuity in the animations of transitions.

``` java
public static void excludeTargets(Transition transition) {
        transition.excludeTarget(android.R.id.statusBarBackground, true);
        transition.excludeTarget(android.R.id.navigationBarBackground, true);
        transition.excludeTarget(R.id.toolbar, true);
}
```

![hammerheadmra58ksaulmm10132015235423](https://cloud.githubusercontent.com/assets/3531999/10469475/cc0af85e-7205-11e5-96d0-1daca74bc98b.gif)
