### PR TITLE
Fixed activity_fade.xml and activity_slide.xml code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Transitions are defined on XML files in `res/transition`
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<fade xmlns:android="http://schemas.android.com/apk/res/
+<fade xmlns:android="http://schemas.android.com/apk/res/"
     android:duration="1000"/>
 
 ```
@@ -39,7 +39,7 @@ Transitions are defined on XML files in `res/transition`
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<slide xmlns:android="http://schemas.android.com/apk/res/
+<slide xmlns:android="http://schemas.android.com/apk/res/"
     android:duration="1000"/>
 
 ```


### PR DESCRIPTION
There was a missing closing `"` in both XML sample codes.